### PR TITLE
Allowing all course formats

### DIFF
--- a/block_massaction.php
+++ b/block_massaction.php
@@ -36,11 +36,7 @@ class block_massaction extends block_base {
      * @see block_base::applicable_formats()
      */
     function applicable_formats() {
-<<<<<<< HEAD
 	return array('course-view' => true, 'mod' => false, 'tag' => false);
-=======
-        return array('course-view' => true, 'mod' => false, 'tag' => false);
->>>>>>> 2c7889bfeab856f4c2e61cff0846c55caad64ebf
     }
 
 

--- a/block_massaction.php
+++ b/block_massaction.php
@@ -36,10 +36,7 @@ class block_massaction extends block_base {
      * @see block_base::applicable_formats()
      */
     function applicable_formats() {
-        return array('course-view-weeks'        => true,
-                     'course-view-topics'       => true,
-                     'course-view-topcoll'      => true,
-                     'course-view-flexsections' => true);
+	return array('course-view' => true, 'mod' => false, 'tag' => false);
     }
 
 


### PR DESCRIPTION
We created our own course formats and so specifying particular course formats is too inflexible when this can easily be widened without having to specifically code for it.